### PR TITLE
`[FIX]` - Removed postinstall script issue

### DIFF
--- a/example.docker-compose.yml
+++ b/example.docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 5000:5000
     volumes:
       - .:/home/node/app/daniels-steaks-api
-    command: sh -c "npm install && bun postinstall && bun dev"
+    command: sh -c "npm install && npm run build && bun dev"
     environment:
       - DB_ENGINE=
       - DB_SERVER=

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "dev": "ts-node-dev --transpile-only --ignore-watch node_modules src/server.ts",
     "build": "rm -rf build/ && tsc",
     "start": "node build/server.js",
-    "format": "prettier --write src/",
-    "postinstall": "tsc"
+    "format": "prettier --write src/"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",


### PR DESCRIPTION
### DESCRIÇÃO
O script `postinstall` estava causando um bug no ambiente da API. Ele foi removido e agora o docker-compose está usando o script `build` ao invés de rodar o outro automaticamente.